### PR TITLE
REST API configuration fix

### DIFF
--- a/waves.custom.conf
+++ b/waves.custom.conf
@@ -90,6 +90,7 @@ waves {
     bind-address = "0.0.0.0"
     port = 6869
     api-key-hash = "BNejVjPAWUrXJTqNrTboGPENAJt9PXnmfdtBgMSgs1u3"
+    minimum-peers = 0
   }
 
   miner {


### PR DESCRIPTION
Set rest-api.minumum-peers to 0, otherwise it requires to run several instances of node to interact with it